### PR TITLE
Don't extend from aliases: it breaks the inheritence chain.

### DIFF
--- a/services/twitter/js.js
+++ b/services/twitter/js.js
@@ -19,7 +19,7 @@ var pf = wp.media.view.MediaFrame.Post;
 
 jQuery( function( $ ) {
 
-	wp.media.view.MediaFrame.Post = pf.extend({
+	wp.media.view.MediaFrame.Post = wp.media.view.MediaFrame.Post.extend({
 
 		initialize: function() {
 


### PR DESCRIPTION
If another plugin extends wp.media.view.MediaFrame.Post (such as my new getty-images plugin,) extending by using an alias causes the plugin to break. I really don't know why, but this fixes it and does not break your code.
