### PR TITLE
Instagram integration

### DIFF
--- a/js/mexp.js
+++ b/js/mexp.js
@@ -129,6 +129,11 @@ media.view.MEXP = media.View.extend({
 		jQuery( '.mexp-pagination' ).click( function( event ) {
 			_this.paginate( event );
 		} );
+		
+		if ( _this.model.get( 'fetchOnRender' ) ) {
+			_this.model.set( 'fetchOnRender', false );
+			_this.fetchItems();
+		}
 
 	},
 
@@ -535,7 +540,8 @@ media.controller.MEXP = media.controller.State.extend({
 				params : {},
 				page   : null,
 				min_id : null,
-				max_id : null
+				max_id : null,
+				fetchOnRender : options.tabs[ tab ].fetchOnRender,
 			}) );
 
 		}

--- a/media-explorer.php
+++ b/media-explorer.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Media Explorer
-Description: Extends the Media Manager to add support for external media services (currently only Twitter and YouTube).
+Description: Extends the Media Manager to add support for external media services (currently Twitter, YouTube, and Instagram).
 Version:     1.2
 Author:      Code For The People Ltd, Automattic
 Text Domain: mexp

--- a/mexp-creds.php
+++ b/mexp-creds.php
@@ -40,3 +40,15 @@ function mexp_youtube_developer_key_callback() {
 	return '';
 
 }
+
+add_filter( 'mexp_instagram_credentials', 'mexp_instagram_credentials_callback' );
+
+function mexp_instagram_credentials_callback( $credentials ) {
+
+	// Add your developer key here.
+	// Get your developer key at: <https://instagram.com/developer>
+	return array( 
+		'access_token' => '',
+	);
+
+}

--- a/mexp-keyring-user-creds.php
+++ b/mexp-keyring-user-creds.php
@@ -1,0 +1,65 @@
+<?php
+/*
+Plugin Name: MEXP Keyring Credentials
+Description: MEXP Keyring Credentials
+Version:     1.0
+Author:      Michael Blouin, Automattic
+Author URI:  http://automattic.com
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
+
+add_filter( 'mexp_instagram_user_credentials', 'mexp_instagram_user_credentials_callback' );
+
+function mexp_instagram_user_credentials_callback( $credentials ) {
+	
+	if ( ! class_exists( 'Keyring') ) {
+		return $credentials;
+	}
+
+	// Check that the instagram service is setup
+	$keyring = Keyring::init()->get_service_by_name( 'instagram' );
+	if ( is_null( $keyring ) ) {
+		return $credentials;
+	}
+	
+	$keyring_store = Keyring::init()->get_token_store();
+	
+	// Hacky time, Keyring is designed to handle requests, but we're just stealing its access_token.
+	if ( method_exists( $keyring_store, 'get_tokens_by_user' ) ) {
+		
+		// The wpcom version uses the get_tokens_by_user method
+		$users_tokens = $keyring_store->get_tokens_by_user( get_current_user_id() );
+		
+		if ( in_array( 'instagram', $users_tokens ) ) {
+			$credentials['access_token'] = $users_tokens['instagram'][0]->token;
+		}
+		
+	} elseif ( method_exists( $keyring_store, 'get_tokens' ) ) {
+		
+		// The released version uses the get_tokens method
+		$users_tokens = $keyring_store->get_tokens(
+				array(
+					'service' => 'instagram',
+					'user_id' => get_current_user_id(),
+				)
+			);
+		
+		if ( count( $users_tokens ) > 0 ) {
+			$credentials['access_token'] = $users_tokens[0]->token;
+		}
+		
+	}
+	
+	return $credentials;
+
+}

--- a/services/instagram/js.js
+++ b/services/instagram/js.js
@@ -1,0 +1,14 @@
+/*
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
+
+// EMPTY SOURCE FILE IS EMPTY

--- a/services/instagram/service.php
+++ b/services/instagram/service.php
@@ -137,9 +137,8 @@ class MEXP_Instagram_Service extends MEXP_Service {
 			$params['access_token'] = $credentials['access_token'];
 		}
 
-		$query_params = http_build_query( $params, null, '&' );
+		$url = add_query_arg( $params, "$host/$version/$endpoint/" );
 
-		$url = "$host/$version/$endpoint/?$query_params";
 		$response = wp_remote_get( $url );
 
 		$code = wp_remote_retrieve_response_code( $response );

--- a/services/instagram/service.php
+++ b/services/instagram/service.php
@@ -1,0 +1,264 @@
+<?php
+/*
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
+
+defined( 'ABSPATH' ) or die();
+
+class MEXP_Instagram_Service extends MEXP_Service {
+
+	public function __construct() {
+
+		require_once dirname( __FILE__ ) . '/template.php';
+
+		# Go!
+		$this->set_template( new MEXP_Instagram_Template );
+
+	}
+
+	public function load() {
+
+		add_action( 'mexp_enqueue', array( $this, 'enqueue_statics' ) );
+
+		add_filter( 'mexp_tabs', array( $this, 'tabs' ), 10, 1 );
+
+		add_filter( 'mexp_labels', array( $this, 'labels' ), 10, 1 );
+	}
+
+	public function enqueue_statics() {
+
+		$mexp = Media_Explorer::init();
+
+		wp_enqueue_script(
+			'mexp-service-instagram',
+			$mexp->plugin_url( 'services/instagram/js.js' ),
+			array( 'jquery', 'mexp' ),
+			$mexp->plugin_ver( 'services/instagram/js.js' )
+		);
+
+		wp_enqueue_style(
+			'mexp-service-instagram-css',
+			$mexp->plugin_url( 'services/instagram/style.css' ),
+			array(),
+			$mexp->plugin_ver( 'services/instagram/style.css' )
+		);
+
+	}
+
+	public function request( array $request ) {
+		$params = $request['params'];
+		$tab 	= $request['tab'];
+
+		$query_params = array();
+
+		if ( isset( $params['q'] ) )
+			$q = $query_params['q'] = sanitize_title_with_dashes( $params['q'] );
+
+		switch ( $tab ) {
+			case 'tag':
+				$endpoint = "tags/{$q}/media/recent";
+				break;
+
+			case 'by_user':
+				$user_id = $this->get_user_id( $q );
+				$endpoint = "users/{$user_id}/media/recent";
+				break;
+
+			case 'mine':
+				$credentials = $this->get_user_credentials();
+				$query_params['access_token'] = $credentials['access_token'];
+				$endpoint = 'users/self/media/recent';
+				break;
+
+			case 'feed':
+				$credentials = $this->get_user_credentials();
+				$query_params['access_token'] = $credentials['access_token'];
+				$endpoint = 'users/self/feed';
+				break;
+
+			case 'popular':
+			default:
+				$endpoint = 'media/popular';
+		}
+
+		if ( !empty( $request['max_id'] ) )
+			$query_params['max_id'] = $request['max_id'];
+
+		$response = $this->do_request( $endpoint, $query_params );
+
+		if ( 200 == $response['code'] || 400 == $response['code'] ) {
+
+			return $this->response( $response );
+
+		} else {
+
+			return new WP_Error(
+				'mexp_instagram_failed_request',
+				sprintf( __( 'Could not connect to Instagram (error %s).', 'mexp' ),
+					esc_html( $response['code'] )
+				)
+			);
+
+		}
+
+	}
+
+	public function do_request( $endpoint, $params = array() ) {
+		$host = 'https://api.instagram.com';
+		$version = 'v1';
+		if ( !isset( $params['access_token'] ) ) {
+			$credentials = $this->get_generic_credentials();
+			$params['access_token'] = $credentials['access_token'];
+		}
+
+		$query_params = http_build_query( $params, null, '&' );
+
+		$url = "$host/$version/$endpoint/?$query_params";
+		$response = wp_remote_get( $url );
+
+		$code = wp_remote_retrieve_response_code( $response );
+
+		$data = array();
+		if ( 200 == $code )
+			$data = json_decode( wp_remote_retrieve_body( $response ) )->data;
+
+		return array(
+			'code' => $code,
+			'data' => $data,
+		);
+
+	}
+
+	public function get_user_id( $username ) {
+		$response = $this->do_request( 'users/search', array( 'q' => $username ) );
+
+		if ( 200 == $response['code'] ) {
+			foreach ( $response['data'] as $user ) {
+				if ( $user->username == $username ) {
+					return $user->id;
+				}
+			}
+		}
+
+		return 0;
+	}
+
+	public function response( $r ) {
+
+		if ( empty( $r['data'] ) )
+			return false;
+
+		$response = new MEXP_Response;
+
+		foreach ( $r['data'] as $result ) {
+
+			$item = new MEXP_Response_Item;
+
+			$item->set_id( $result->id );
+			$item->set_url( $result->link );
+			$item->set_content( $result->caption->text );
+			$item->set_thumbnail( set_url_scheme( $result->images->thumbnail->url ) );
+			$item->set_date( $result->created_time );
+			$item->set_date_format( 'g:i A - j M y' );
+
+			$item->add_meta( 'user', array(
+				'username' => $result->user->username,
+			) );
+
+			$response->add_item( $item );
+
+		}
+
+		// Pagination details
+		$response->add_meta( 'max_id', $result->id );
+
+		return $response;
+
+	}
+
+	public function tabs( array $tabs ) {
+		$tabs['instagram'] = array();
+
+		if ( Keyring::init()->get_service_by_name( 'instagram' )->is_connected() ) {
+			$tabs['instagram']['mine'] = array(
+				'text'       => _x( 'My Instagrams', 'Tab title', 'mexp' ),
+				'defaultTab' => true,
+				'fetchOnRender' => true,
+			);
+			$tabs['instagram']['feed'] = array(
+				'text'       => _x( 'My Feed', 'Tab title', 'mexp' ),
+				'fetchOnRender' => true,
+			);
+		}
+
+		$tabs['instagram']['popular'] = array(
+			'text'       => _x( 'Browse Popular', 'Tab title', 'mexp'),
+			'defaultTab' => empty( $tabs['instagram'] ),
+			'fetchOnRender' => true,
+		);
+		$tabs['instagram']['tag'] = array(
+			'text' => _x( 'With Tag', 'Tab title', 'mexp'),
+		);
+		$tabs['instagram']['by_user'] = array(
+			'text' => _x( 'By User', 'Tab title', 'mexp'),
+		);
+
+		return $tabs;
+	}
+
+	public function labels( array $labels ) {
+		$labels['instagram'] = array(
+			'title'     => __( 'Insert Instagram (a8c)', 'mexp' ),
+			# @TODO the 'insert' button text gets reset when selecting items. find out why.
+			'insert'    => __( 'Insert Instagram (a8c)', 'mexp' ),
+			'noresults' => __( 'No pics matched your search query', 'mexp' ),
+			'gmaps_url' => set_url_scheme( 'http://maps.google.com/maps/api/js' ),
+			'loadmore'  => __( 'Load more pics', 'mexp' ),
+		);
+
+		return $labels;
+	}
+
+	private function get_generic_credentials() {
+
+		if ( is_null( $this->generic_credentials ) )
+			$this->generic_credentials = (array) apply_filters( 'mexp_instagram_credentials', array() );
+
+		return $this->generic_credentials;
+
+	}
+
+	private function get_user_credentials() {
+
+		if ( is_null( $this->user_credentials ) ) {
+			// Hacky time, Keyring is designed to handle requests, but we're just stealing its access_token.
+			$keyring = Keyring::init()->get_service_by_name( 'instagram' );
+			$users_tokens = Keyring::init()->get_token_store()->get_tokens_by_user( get_current_user_id() );
+			$this->user_credentials = array(
+				'access_token' => $users_tokens['instagram'][0]->token
+			);
+		}
+
+		return $this->user_credentials;
+
+	}
+
+}
+
+add_filter( 'mexp_services', 'mexp_service_instagram' );
+
+function mexp_service_instagram( array $services ) {
+	if ( is_automattician() )
+		$services['instagram'] = new MEXP_Instagram_Service;
+
+	return $services;
+}

--- a/services/instagram/service.php
+++ b/services/instagram/service.php
@@ -248,7 +248,6 @@ class MEXP_Instagram_Service extends MEXP_Service {
 			// @TODO the 'insert' button text gets reset when selecting items. find out why.
 			'insert'    => __( 'Insert Instagram', 'mexp' ),
 			'noresults' => __( 'No pics matched your search query', 'mexp' ),
-			'gmaps_url' => set_url_scheme( 'http://maps.google.com/maps/api/js' ),
 			'loadmore'  => __( 'Load more pics', 'mexp' ),
 		);
 

--- a/services/instagram/service.php
+++ b/services/instagram/service.php
@@ -220,9 +220,9 @@ class MEXP_Instagram_Service extends MEXP_Service {
 
 	public function labels( array $labels ) {
 		$labels['instagram'] = array(
-			'title'     => __( 'Insert Instagram (a8c)', 'mexp' ),
+			'title'     => __( 'Insert Instagram', 'mexp' ),
 			# @TODO the 'insert' button text gets reset when selecting items. find out why.
-			'insert'    => __( 'Insert Instagram (a8c)', 'mexp' ),
+			'insert'    => __( 'Insert Instagram', 'mexp' ),
 			'noresults' => __( 'No pics matched your search query', 'mexp' ),
 			'gmaps_url' => set_url_scheme( 'http://maps.google.com/maps/api/js' ),
 			'loadmore'  => __( 'Load more pics', 'mexp' ),

--- a/services/instagram/service.php
+++ b/services/instagram/service.php
@@ -98,7 +98,11 @@ class MEXP_Instagram_Service extends MEXP_Service {
 
 		$response = $this->do_request( $endpoint, $query_params );
 
-		if ( 200 == $response['code'] || 400 == $response['code'] ) {
+		if ( is_wp_error( $response ) ) {
+			
+			return $response;
+			
+		} elseif ( 200 == $response['code'] || 400 == $response['code'] ) {
 
 			return $this->response( $response );
 
@@ -120,6 +124,14 @@ class MEXP_Instagram_Service extends MEXP_Service {
 		$version = 'v1';
 		if ( !isset( $params['access_token'] ) ) {
 			$credentials = $this->get_generic_credentials();
+
+			if ( ! isset( $credentials['access_token'] ) ) {
+				return new WP_Error(
+					'mexp_instagram_no_connection',
+					__( 'oAuth connection to Instagram not found.', 'mexp' )
+				);
+			}
+
 			$params['access_token'] = $credentials['access_token'];
 		}
 
@@ -144,7 +156,7 @@ class MEXP_Instagram_Service extends MEXP_Service {
 	public function get_user_id( $username ) {
 		$response = $this->do_request( 'users/search', array( 'q' => $username ) );
 
-		if ( 200 == $response['code'] ) {
+		if ( ! is_wp_error( $response ) && 200 == $response['code'] ) {
 			foreach ( $response['data'] as $user ) {
 				if ( $user->username == $username ) {
 					return $user->id;

--- a/services/instagram/service.php
+++ b/services/instagram/service.php
@@ -16,6 +16,9 @@ defined( 'ABSPATH' ) or die();
 
 class MEXP_Instagram_Service extends MEXP_Service {
 
+	public $credentials = null;
+	public $generic_credentials = null;
+	
 	public function __construct() {
 
 		require_once dirname( __FILE__ ) . '/template.php';
@@ -188,7 +191,7 @@ class MEXP_Instagram_Service extends MEXP_Service {
 	public function tabs( array $tabs ) {
 		$tabs['instagram'] = array();
 
-		if ( Keyring::init()->get_service_by_name( 'instagram' )->is_connected() ) {
+		if ( class_exists( 'Keyring' ) && Keyring::init()->get_service_by_name( 'instagram' )->is_connected() ) {
 			$tabs['instagram']['mine'] = array(
 				'text'       => _x( 'My Instagrams', 'Tab title', 'mexp' ),
 				'defaultTab' => true,
@@ -239,7 +242,7 @@ class MEXP_Instagram_Service extends MEXP_Service {
 
 	private function get_user_credentials() {
 
-		if ( is_null( $this->user_credentials ) ) {
+		if ( class_exists( 'Keyring' ) && is_null( $this->user_credentials ) ) {
 			// Hacky time, Keyring is designed to handle requests, but we're just stealing its access_token.
 			$keyring = Keyring::init()->get_service_by_name( 'instagram' );
 			$users_tokens = Keyring::init()->get_token_store()->get_tokens_by_user( get_current_user_id() );
@@ -257,8 +260,7 @@ class MEXP_Instagram_Service extends MEXP_Service {
 add_filter( 'mexp_services', 'mexp_service_instagram' );
 
 function mexp_service_instagram( array $services ) {
-	if ( is_automattician() )
-		$services['instagram'] = new MEXP_Instagram_Service;
+	$services['instagram'] = new MEXP_Instagram_Service;
 
 	return $services;
 }

--- a/services/instagram/service.php
+++ b/services/instagram/service.php
@@ -159,7 +159,7 @@ class MEXP_Instagram_Service extends MEXP_Service {
 		$response = $this->do_request( 'users/search', array( 'q' => $username ) );
 
 		if ( ! is_wp_error( $response ) && 200 == $response['code'] ) {
-			foreach ( $response['data'] as $user ) {
+			foreach ( $response['data']->data as $user ) {
 				if ( $user->username == $username ) {
 					return $user->id;
 				}

--- a/services/instagram/service.php
+++ b/services/instagram/service.php
@@ -202,8 +202,13 @@ class MEXP_Instagram_Service extends MEXP_Service {
 
 		// Pagination details
 		if ( !empty( $r['data']->pagination ) ) {
-			$response->add_meta( 'max_id', $r['data']->pagination->next_max_id );
-			$response->add_meta( 'min_id', $r['data']->pagination->next_min_id );
+			if ( isset( $r['data']->pagination->next_max_id ) ) {
+				$response->add_meta( 'max_id', $r['data']->pagination->next_max_id );
+			}
+			
+			if ( isset( $r['data']->pagination->next_min_id ) ) {
+				$response->add_meta( 'min_id', $r['data']->pagination->next_min_id );
+			}
 		}
 
 		return $response;

--- a/services/instagram/service.php
+++ b/services/instagram/service.php
@@ -23,7 +23,7 @@ class MEXP_Instagram_Service extends MEXP_Service {
 
 		require_once dirname( __FILE__ ) . '/template.php';
 
-		# Go!
+		// Go!
 		$this->set_template( new MEXP_Instagram_Template );
 
 	}
@@ -63,8 +63,9 @@ class MEXP_Instagram_Service extends MEXP_Service {
 
 		$query_params = array();
 
-		if ( isset( $params['q'] ) )
+		if ( isset( $params['q'] ) ) {
 			$q = $query_params['q'] = sanitize_title_with_dashes( $params['q'] );
+		}
 
 		switch ( $tab ) {
 			case 'tag':
@@ -93,9 +94,10 @@ class MEXP_Instagram_Service extends MEXP_Service {
 				$endpoint = 'media/popular';
 		}
 
-		if ( !empty( $request['max_id'] ) )
+		if ( !empty( $request['max_id'] ) ) {
 			$query_params['max_id'] = $request['max_id'];
-
+		}
+		
 		$response = $this->do_request( $endpoint, $query_params );
 
 		if ( is_wp_error( $response ) ) {
@@ -143,8 +145,9 @@ class MEXP_Instagram_Service extends MEXP_Service {
 		$code = wp_remote_retrieve_response_code( $response );
 
 		$data = array();
-		if ( 200 == $code )
+		if ( 200 == $code ) {
 			$data = json_decode( wp_remote_retrieve_body( $response ) );
+		}
 
 		return array(
 			'code' => $code,
@@ -169,8 +172,9 @@ class MEXP_Instagram_Service extends MEXP_Service {
 
 	public function response( $r ) {
 
-		if ( empty( $r['data'] ) )
+		if ( empty( $r['data'] ) ) {
 			return false;
+		}
 
 		$response = new MEXP_Response;
 
@@ -241,7 +245,7 @@ class MEXP_Instagram_Service extends MEXP_Service {
 	public function labels( array $labels ) {
 		$labels['instagram'] = array(
 			'title'     => __( 'Insert Instagram', 'mexp' ),
-			# @TODO the 'insert' button text gets reset when selecting items. find out why.
+			// @TODO the 'insert' button text gets reset when selecting items. find out why.
 			'insert'    => __( 'Insert Instagram', 'mexp' ),
 			'noresults' => __( 'No pics matched your search query', 'mexp' ),
 			'gmaps_url' => set_url_scheme( 'http://maps.google.com/maps/api/js' ),
@@ -253,8 +257,9 @@ class MEXP_Instagram_Service extends MEXP_Service {
 
 	private function get_generic_credentials() {
 
-		if ( is_null( $this->generic_credentials ) )
+		if ( is_null( $this->generic_credentials ) ) {
 			$this->generic_credentials = (array) apply_filters( 'mexp_instagram_credentials', array() );
+		}
 
 		return $this->generic_credentials;
 
@@ -262,8 +267,9 @@ class MEXP_Instagram_Service extends MEXP_Service {
 
 	private function get_user_credentials() {
 		
-		if ( is_null( $this->user_credentials ) )
+		if ( is_null( $this->user_credentials ) ) {
 			$this->user_credentials = (array) apply_filters( 'mexp_instagram_user_credentials', array() );
+		}
 
 		return $this->user_credentials;
 

--- a/services/instagram/service.php
+++ b/services/instagram/service.php
@@ -144,7 +144,7 @@ class MEXP_Instagram_Service extends MEXP_Service {
 
 		$data = array();
 		if ( 200 == $code )
-			$data = json_decode( wp_remote_retrieve_body( $response ) )->data;
+			$data = json_decode( wp_remote_retrieve_body( $response ) );
 
 		return array(
 			'code' => $code,
@@ -174,8 +174,7 @@ class MEXP_Instagram_Service extends MEXP_Service {
 
 		$response = new MEXP_Response;
 
-		foreach ( $r['data'] as $result ) {
-
+		foreach ( $r['data']->data as $result ) {
 			$item = new MEXP_Response_Item;
 
 			$item->set_id( $result->id );
@@ -199,7 +198,10 @@ class MEXP_Instagram_Service extends MEXP_Service {
 		}
 
 		// Pagination details
-		$response->add_meta( 'max_id', $result->id );
+		if ( !empty( $r['data']->pagination ) ) {
+			$response->add_meta( 'max_id', $r['data']->pagination->next_max_id );
+			$response->add_meta( 'min_id', $r['data']->pagination->next_min_id );
+		}
 
 		return $response;
 

--- a/services/instagram/service.php
+++ b/services/instagram/service.php
@@ -169,7 +169,8 @@ class MEXP_Instagram_Service extends MEXP_Service {
 			$item->set_id( $result->id );
 			$item->set_url( $result->link );
 			
-			if ( property_exists( $result->caption, 'text' ) ) {
+			// Not all results have a caption
+			if ( is_object( $result->caption ) ) {
 				$item->set_content( $result->caption->text );
 			}
 			
@@ -195,8 +196,8 @@ class MEXP_Instagram_Service extends MEXP_Service {
 	public function tabs( array $tabs ) {
 		$tabs['instagram'] = array();
 
-		$this->get_user_credentials();
-		if ( ! empty( $this->user_credentials ) ) {
+		$user_creds = $this->get_user_credentials();
+		if ( ! empty( $user_creds ) ) {
 			$tabs['instagram']['mine'] = array(
 				'text'       => _x( 'My Instagrams', 'Tab title', 'mexp' ),
 				'defaultTab' => true,

--- a/services/instagram/style.css
+++ b/services/instagram/style.css
@@ -1,0 +1,19 @@
+.mexp-content-instagram .attachment {
+	width: 200px;
+}
+
+.mexp-content-instagram .attachment .mexp-item-instagram {
+	height: 235px;
+	overflow: hidden;
+	padding: 10px;
+}
+
+.mexp-content-instagram .mexp-item-thumb img {
+	width: 150px;
+	height: 150px;
+}
+
+.mexp-content-instagram .description {
+	float: left;
+	margin: 7px 10px;
+}

--- a/services/instagram/template.php
+++ b/services/instagram/template.php
@@ -13,7 +13,7 @@ class MEXP_Instagram_Template extends MEXP_Template {
 				</div>
 				<div class="mexp-item-main">
 					<div class="mexp-item-content">
-						<strong>{{ data.meta.user.username }}:</strong> {{ data.content }}
+						<strong>{{ data.meta.user.username }}{{ data.content ? ':' : '' }}</strong> {{ data.content }}
 					</div>
 					<div class="mexp-item-date">
 						{{ data.date }}

--- a/services/instagram/template.php
+++ b/services/instagram/template.php
@@ -1,0 +1,101 @@
+<?php
+
+class MEXP_Instagram_Template extends MEXP_Template {
+
+	public function thumbnail( $id ) {}
+
+	public function item( $id, $tab ) {
+		?>
+		<div id="mexp-item-instagram-<?php echo esc_attr( $tab ); ?>-{{ data.id }}" class="mexp-item-area mexp-item-instagram" data-id="{{ data.id }}">
+			<div class="mexp-item-container clearfix">
+				<div class="mexp-item-thumb">
+					<img src="{{ data.thumbnail }}">
+				</div>
+				<div class="mexp-item-main">
+					<div class="mexp-item-content">
+						<strong>{{ data.meta.user.username }}:</strong> {{ data.content }}
+					</div>
+					<div class="mexp-item-date">
+						{{ data.date }}
+					</div>
+				</div>
+			</div>
+		</div>
+		<a href="#" id="mexp-check-{{ data.id }}" data-id="{{ data.id }}" class="check" title="<?php esc_attr_e( 'Deselect', 'mexp' ); ?>">
+			<div class="media-modal-icon"></div>
+		</a>
+		<?php
+	}
+
+	public function search( $id, $tab ) {
+
+		switch ( $tab ) {
+
+			case 'tag':
+				?>
+				<form action="#" class="mexp-toolbar-container clearfix">
+					<input
+						type="text"
+						name="q"
+						value="{{ data.params.tag }}"
+						class="mexp-input-text mexp-input-search"
+						size="40"
+						placeholder="<?php esc_attr_e( 'Enter a tag', 'mexp' ); ?>"
+						>
+					<input class="button button-large" type="submit" value="<?php esc_attr_e( 'Search', 'mexp') ?>">
+					<input type="hidden" name="type" value="tag">
+					<div class="spinner"></div>
+				</form>
+				<?php
+			break;
+
+			case 'by_user':
+
+				?>
+				<form action="#" class="mexp-toolbar-container clearfix">
+					<input
+						type="text"
+						name="q"
+						value="{{ data.params.by_user }}"
+						class="mexp-input-text mexp-input-search"
+						size="40"
+						placeholder="<?php esc_attr_e( 'Enter an Instagram Username', 'mexp' ); ?>"
+						>
+					<input class="button button-large" type="submit" value="<?php esc_attr_e( 'Search', 'mexp') ?>">
+					<input type="hidden" name="type" value="by_user">
+					<div class="spinner"></div>
+				</form>
+				<?php
+			break;
+
+			case 'mine':
+				?>
+				<form action="#" class="mexp-toolbar-container clearfix">
+					<span class="description"><?php _e( 'A selection of your own recent Instagrams.', 'mexp' ) ?></span>
+					<input type="hidden" name="type" value="mine">
+					<div class="spinner"></div>
+				</form>
+				<?php
+			break;
+
+			case 'feed':
+				?>
+				<form action="#" class="mexp-toolbar-container clearfix">
+					<span class="description"><?php _e( 'The latest Instagrams from your personal feed.', 'mexp' ) ?></span>
+					<input type="hidden" name="type" value="mine">
+					<div class="spinner"></div>
+				</form>
+				<?php
+			break;
+
+			case 'popular':
+				?>
+				<form action="#" class="mexp-toolbar-container clearfix">
+					<span class="description"><?php _e( 'A selection of trending content on Instagram.', 'mexp' ) ?></span>
+					<input type="hidden" name="type" value="popular">
+					<div class="spinner"></div>
+				</form>
+				<?php
+		}
+	}
+}


### PR DESCRIPTION
See #45

Adds Instagram integration. Mainly importing and fixing 3bdd301 which is not my code.

Adds a new filter `mexp_instagram_credentials` for grabbing generic Instagram credentials that will be used to query for trending pictures. Also has a `mexp_instagram_user_credentials` filter used to supply a user access token in order to fetch personalized content.

The MEXP Keyring Credentials plugin that is added allows Instagram to pull user credentials from Keyring, if it is installed and has the Instagram service activated. This plugin supports both the current released version of Keyring and the development one in use on WP.com.

Adds the ability for a page to automatically have its content fetched when it is open. This is useful for things like pulling trending content when that page is navigated to.

Closes #45
