### PR TITLE
Use wp.Backbone.View to ensure compatibility with Backbone 1.1.

### DIFF
--- a/js/mexp.js
+++ b/js/mexp.js
@@ -15,7 +15,7 @@ var media = wp.media;
 
 // VIEW: MEDIA ITEM:
 
-media.view.MEXPItem = Backbone.View.extend({
+media.view.MEXPItem = wp.Backbone.View.extend({
 
     tagName   : 'li',
     className : 'mexp-item attachment',

--- a/services/youtube/js.js
+++ b/services/youtube/js.js
@@ -222,7 +222,7 @@ wp.media.view.Toolbar.MEXP = toolbarView.extend({
 
 		toolbarView.prototype.initialize.apply( this, arguments );
 
-		this.set( 'spinner', new Backbone.View({
+		this.set( 'spinner', new wp.Backbone.View({
 			tagName: 'span',
 			className: 'spinner spinner-bottom',
 			priority: -20,


### PR DESCRIPTION
WordPress 3.9 will ship with Backbone 1.1. One of the changes is that:

> Backbone Views no longer automatically attach options passed to the constructor as this.options

So let's extend `wp.Backbone.View` which will attach options.
