### PR TITLE
Make the Keyring integration more generic, add support for Twitter

### DIFF
--- a/mexp-creds.php
+++ b/mexp-creds.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: MEXP oAuth Credentials
-Description: MEXP oAuth Credentials
+Description: A blank template plugin for you to enter your credentials for Twitter, YouTube and Instagram (i.e. this plugin will not work without entering your details).
 Version:     1.0
 Author:      John Blackbourn
 Author URI:  http://johnblackbourn.com/

--- a/mexp-keyring-user-creds.php
+++ b/mexp-keyring-user-creds.php
@@ -1,10 +1,9 @@
 <?php
 /*
 Plugin Name: MEXP Keyring Credentials
-Description: MEXP Keyring Credentials
+Description: Allows the use of the <a href="http://wordpress.org/plugins/keyring/">Keyring plugin</a> to authenticate for Twitter, Instagram and YouTube services to Media Explorer.
 Version:     1.0
-Author:      Michael Blouin, Automattic
-Author URI:  http://automattic.com
+Author:      <a href="http://automattic.com">Michael Blouin (Automattic)</a>, <a href="http://codeforthepeople.com/">John Blackbourn (Code For The People)</a>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/mexp-keyring-user-creds.php
+++ b/mexp-keyring-user-creds.php
@@ -18,20 +18,19 @@ GNU General Public License for more details.
 
 */
 
-add_filter( 'mexp_instagram_user_credentials', 'mexp_instagram_user_credentials_callback' );
-
-function mexp_instagram_user_credentials_callback( $credentials ) {
+function mexp_get_keyring_oauth2_credentials( $service, array $credentials ) {
 	
 	if ( ! class_exists( 'Keyring') ) {
 		return $credentials;
 	}
 
-	// Check that the instagram service is setup
-	$keyring = Keyring::init()->get_service_by_name( 'instagram' );
+	// Check that the service is set up
+	$keyring = Keyring::init()->get_service_by_name( $service );
+
 	if ( is_null( $keyring ) ) {
 		return $credentials;
 	}
-	
+
 	$keyring_store = Keyring::init()->get_token_store();
 	
 	// Hacky time, Keyring is designed to handle requests, but we're just stealing its access_token.
@@ -40,8 +39,8 @@ function mexp_instagram_user_credentials_callback( $credentials ) {
 		// The wpcom version uses the get_tokens_by_user method
 		$users_tokens = $keyring_store->get_tokens_by_user( get_current_user_id() );
 		
-		if ( in_array( 'instagram', $users_tokens ) ) {
-			$credentials['access_token'] = $users_tokens['instagram'][0]->token;
+		if ( isset( $users_tokens[$service] ) ) {
+			$credentials['access_token'] = $users_tokens[$service][0]->token;
 		}
 		
 	} elseif ( method_exists( $keyring_store, 'get_tokens' ) ) {
@@ -49,7 +48,7 @@ function mexp_instagram_user_credentials_callback( $credentials ) {
 		// The released version uses the get_tokens method
 		$users_tokens = $keyring_store->get_tokens(
 				array(
-					'service' => 'instagram',
+					'service' => $service,
 					'user_id' => get_current_user_id(),
 				)
 			);
@@ -62,4 +61,65 @@ function mexp_instagram_user_credentials_callback( $credentials ) {
 	
 	return $credentials;
 
+}
+
+function mexp_get_keyring_oauth1_credentials( $service, array $credentials ) {
+
+	if ( ! class_exists( 'Keyring') ) {
+		return $credentials;
+	}
+
+	// Check that the service is set up
+	$keyring = Keyring::init()->get_service_by_name( $service );
+
+	if ( is_null( $keyring ) ) {
+		return $credentials;
+	}
+
+	$keyring_store = Keyring::init()->get_token_store();
+
+	if ( method_exists( $keyring_store, 'get_tokens_by_user' ) ) {
+
+		// The wpcom version uses the get_tokens_by_user method
+		$users_tokens = $keyring_store->get_tokens_by_user( get_current_user_id() );
+
+		if ( isset( $users_tokens[$service] ) ) {
+			$token = $users_tokens[$service];
+			$credentials['consumer_key']       = $keyring->key;
+			$credentials['consumer_secret']    = $keyring->secret;
+			$credentials['oauth_token']        = $token->token->key;
+			$credentials['oauth_token_secret'] = $token->token->secret;
+		}
+
+	} elseif ( method_exists( $keyring_store, 'get_tokens' ) ) {
+
+		// The released version uses the get_tokens method
+		$users_tokens = $keyring_store->get_tokens( array(
+			'service' => $service,
+		) );
+
+		if ( count( $users_tokens ) > 0 ) {
+			$token = $users_tokens[0];
+			$credentials['consumer_key']       = $keyring->key;
+			$credentials['consumer_secret']    = $keyring->secret;
+			$credentials['oauth_token']        = $token->token->key;
+			$credentials['oauth_token_secret'] = $token->token->secret;
+		}
+
+	}
+
+	return $credentials;
+
+}
+
+add_filter( 'mexp_twitter_credentials', 'mexp_twitter_credentials_callback', 99 );
+
+function mexp_twitter_credentials_callback( array $credentials ) {
+	return mexp_get_keyring_oauth1_credentials( 'twitter', $credentials );
+}
+
+add_filter( 'mexp_instagram_user_credentials', 'mexp_instagram_user_credentials_callback', 99 );
+
+function mexp_instagram_credentials_callback( array $credentials ) {
+	return mexp_get_keyring_oauth2_credentials( 'instagram', $credentials );
 }

--- a/mexp-keyring-user-creds.php
+++ b/mexp-keyring-user-creds.php
@@ -127,7 +127,7 @@ function mexp_instagram_user_credentials_callback( array $credentials ) {
 add_filter( 'mexp_youtube_developer_key', 'mexp_youtube_developer_key_callback', 99 );
 
 function mexp_youtube_developer_key_callback( $key ) {
-	$credentials = mexp_get_keyring_oauth2_credentials( 'google-contacts', $credentials );
+	$credentials = mexp_get_keyring_oauth2_credentials( 'google-contacts', array() );
 	if ( isset( $credentials['access_token'] ) ) {
 		return $credentials['access_token'];
 	}

--- a/mexp-keyring-user-creds.php
+++ b/mexp-keyring-user-creds.php
@@ -120,6 +120,6 @@ function mexp_twitter_credentials_callback( array $credentials ) {
 
 add_filter( 'mexp_instagram_user_credentials', 'mexp_instagram_user_credentials_callback', 99 );
 
-function mexp_instagram_credentials_callback( array $credentials ) {
+function mexp_instagram_user_credentials_callback( array $credentials ) {
 	return mexp_get_keyring_oauth2_credentials( 'instagram', $credentials );
 }

--- a/mexp-keyring-user-creds.php
+++ b/mexp-keyring-user-creds.php
@@ -123,3 +123,13 @@ add_filter( 'mexp_instagram_user_credentials', 'mexp_instagram_user_credentials_
 function mexp_instagram_user_credentials_callback( array $credentials ) {
 	return mexp_get_keyring_oauth2_credentials( 'instagram', $credentials );
 }
+
+add_filter( 'mexp_youtube_developer_key', 'mexp_youtube_developer_key_callback', 99 );
+
+function mexp_youtube_developer_key_callback( $key ) {
+	$credentials = mexp_get_keyring_oauth2_credentials( 'google-contacts', $credentials );
+	if ( isset( $credentials['access_token'] ) ) {
+		return $credentials['access_token'];
+	}
+	return $key;
+}


### PR DESCRIPTION
This makes the integration with Keyring a little more generic by introducing `mexp_get_keyring_oauth1_credentials()` and `mexp_get_keyring_oauth2_credentials()`, and it adds support for a Twitter connection.
