### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,24 @@
+{
+	"name"       : "automattic/media-explorer",
+	"description": "Extends the Media Manager to add support for external media services.",
+	"homepage"   : "http://wordpress.org/plugins/media-explorer/",
+	"type"       : "wordpress-plugin",
+	"license"    : "GPL-2.0+",
+	"authors"    : [
+		{
+			"name"    : "Automattic",
+			"homepage": "http://automattic.com/"
+		},
+		{
+			"name"    : "Code For The People",
+			"homepage": "http://codeforthepeople.com/"
+		}
+	],
+	"support"    : {
+			"issues": "https://github.com/Automattic/media-explorer/issues",
+			"source": "https://github.com/Automattic/media-explorer"
+	},
+	"require": {
+		"composer/installers": "~1.0"
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name"       : "automattic/media-explorer",
 	"description": "Extends the Media Manager to add support for external media services.",
-	"homepage"   : "http://wordpress.org/plugins/media-explorer/",
+	"homepage"   : "https://github.com/Automattic/media-explorer/blob/master/README.md",
 	"type"       : "wordpress-plugin",
 	"license"    : "GPL-2.0+",
 	"authors"    : [


### PR DESCRIPTION
Reissued from a branch, phew.

Having a `composer.json` file handy for those of us assembling their sites using Composer, and harmless otherwise. :)
