### PR TITLE
Fix Instagram integration which needs OAuth credentials for all requests

### DIFF
--- a/services/instagram/service.php
+++ b/services/instagram/service.php
@@ -67,6 +67,11 @@ class MEXP_Instagram_Service extends MEXP_Service {
 			$q = $query_params['q'] = sanitize_title_with_dashes( $params['q'] );
 		}
 
+		$credentials = $this->get_user_credentials();
+		if ( isset( $credentials['access_token'] ) ) {
+			$query_params['access_token'] = $credentials['access_token'];
+		}
+
 		switch ( $tab ) {
 			case 'tag':
 				$endpoint = "tags/{$q}/media/recent";
@@ -78,14 +83,10 @@ class MEXP_Instagram_Service extends MEXP_Service {
 				break;
 
 			case 'mine':
-				$credentials = $this->get_user_credentials();
-				$query_params['access_token'] = $credentials['access_token'];
 				$endpoint = 'users/self/media/recent';
 				break;
 
 			case 'feed':
-				$credentials = $this->get_user_credentials();
-				$query_params['access_token'] = $credentials['access_token'];
 				$endpoint = 'users/self/feed';
 				break;
 


### PR DESCRIPTION
Instagram requests in the "Browse Popular", "With Tag", and "By User" tabs currently fail because the OAuth connection parameters aren't set for these methods. This change fixes that.
