### PR TITLE
Fix visual bugs, Twitter map and error when no search string supplied

### DIFF
--- a/class.mexp.php
+++ b/class.mexp.php
@@ -225,7 +225,8 @@ class Media_Explorer extends MEXP_Plugin {
 			'mexp',
 			$this->plugin_url( 'js/mexp.js' ),
 			array( 'jquery', 'media-views' ),
-			$this->plugin_ver( 'js/mexp.js' )
+			$this->plugin_ver( 'js/mexp.js' ),
+			true
 		);
 
 		wp_localize_script(

--- a/css/mexp.css
+++ b/css/mexp.css
@@ -125,7 +125,7 @@ html.ie8 .media-frame .mexp-content .mexp-item.selected {
 /* ************************ */
 
 .media-frame .mexp-content-twitter .mexp-item {
-	float: none;
+	width: 100%;
 	max-width: 800px;
 	text-align: left;
 	margin: 6px 10px;
@@ -190,7 +190,7 @@ html.ie8 .media-frame .mexp-content .mexp-item.selected {
 }
 
 .media-frame .mexp-item-youtube .mexp-item-main {
-	max-height: 48px;
+	max-height: 52px;
 	overflow: hidden;
 }
 

--- a/js/mexp.js
+++ b/js/mexp.js
@@ -108,7 +108,7 @@ media.view.MEXP = media.View.extend({
 			this.collection = new Backbone.Collection();
 			this.collection.reset( this.model.get( 'items' ) );
 
-			jQuery( '#' + this.service.id + '-loadmore' ).attr( 'disabled', false ).show();
+			jQuery( '#' + this.service.id + '-loadmore' ).attr( 'disabled', false ).css('display', 'block');
 		} else {
 			jQuery( '#' + this.service.id + '-loadmore' ).hide();
 		}
@@ -343,7 +343,7 @@ media.view.MEXP = media.View.extend({
 
 		}
 
-		jQuery( '#' + this.service.id + '-loadmore' ).attr( 'disabled', false ).show();
+		jQuery( '#' + this.service.id + '-loadmore' ).attr( 'disabled', false ).css('display', 'block');
 		this.model.set( 'max_id', response.meta.max_id );
 
 		this.trigger( 'loaded loaded:success', response );
@@ -362,7 +362,7 @@ media.view.MEXP = media.View.extend({
 	fetchedError: function( response ) {
 
 		this.$el.find( '.mexp-error' ).text( response.error_message ).show();
-		jQuery( '#' + this.service.id + '-loadmore' ).attr( 'disabled', false ).show();
+		jQuery( '#' + this.service.id + '-loadmore' ).attr( 'disabled', false ).css('display', 'block');
 		this.trigger( 'loaded loaded:error', response );
 
 	},

--- a/services/twitter/js.js
+++ b/services/twitter/js.js
@@ -21,6 +21,8 @@ wp.media.view.MediaFrame.Post = pf.extend({
 
 	initialize: function() {
 
+		var $ = jQuery;
+
 		pf.prototype.initialize.apply( this, arguments );
 
 		this.on( 'content:render:mexp-service-twitter-content-location', _.bind( function() {

--- a/services/twitter/service.php
+++ b/services/twitter/service.php
@@ -103,6 +103,12 @@ class MEXP_Twitter_Service extends MEXP_Service {
 			'count'       => 20,
 		);
 
+		if ( $request['tab'] != 'location' ) {
+			if ( empty( $params['q'] ) && empty( $params['hashtag'] ) && empty( $params['by_user'] ) && empty( $params['to_user'] ) ) {
+				return false;
+			}
+		}
+
 		if ( isset( $params['coords'] ) and isset( $params['radius'] ) ) {
 			if ( is_array( $params['radius'] ) )
 				$params['radius'] = reset( $params['radius'] );


### PR DESCRIPTION
Fixes:
- Map on Twitter location panel, was failing with $ is undefined on init.
- Inline pagination button. Should be display: block to keep the styles consistent.
- 403 error when attempting to search without a query. This now returns the less-alarming 'No Tweets match your query' notice.