### PR TITLE
use button for pagination link

### DIFF
--- a/js/mexp.js
+++ b/js/mexp.js
@@ -59,7 +59,7 @@ media.view.Toolbar.MEXP = media.view.Toolbar.extend({
 		var serviceName = this.controller.state().id.replace( /mexp-service-/g, '');
 
 		this.set( 'pagination', new media.view.Button({
-			tagName: 'a',
+			tagName: 'button',
 			classes: 'mexp-pagination button button-secondary',
 			id: serviceName + '-loadmore',
 			text: mexp.labels.loadmore,


### PR DESCRIPTION
I think technically this should use a button element here instead of a link.

I ran into this because this element is given the disabled attribute whilst loading more results. However this is not really honoured on links, only buttons, inputs etc. Visually this isn't a problem - CSS handles it OK. But the actual click event is still fired and you can easiliy trigger multiple requests.
