### PR TITLE
Check element is link before return

### DIFF
--- a/js/mexp.js
+++ b/js/mexp.js
@@ -214,7 +214,7 @@ media.view.MEXP = media.View.extend({
 
 	toggleSelectionHandler: function( event ) {
 
-		if ( event.target.href )
+		if ( 'A' === event.target.nodeName && event.target.href )
 			return;
 
 		var target = jQuery( '#' + event.currentTarget.id );


### PR DESCRIPTION
On IE11, you cannot select an item by clicking on the actual thumbnail image in the explorer. It works fine if you click the title, or the area around the image.

I think this problem is caused by a quirk in IE, where `event.target.href` returns the image `src`. As you are checking this isn't empty befor toggling the selection, this breaks on IE. 

A simple fix is to check that the event target with an href is also a link element.
