### PR TITLE
Change 'http://...' absolute URL strings to 'https://...'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the next steps:
 * Clone this repo in the plugins folder of your WordPress install with `git
 clone https://github.com/Automattic/media-explorer.git`.
 * Get your credentials:
-  * [Twitter](http://dev.twitter.com)
+  * [Twitter](https://dev.twitter.com)
   * [Instagram](https://instagram.com/developer).
   * [YouTube](https://developers.google.com/youtube/v3/).
     * For YouTube, you'll have to create or use an existing project in your [Google Developers Console](https://cloud.google.com/console/project)

--- a/composer.json
+++ b/composer.json
@@ -7,11 +7,11 @@
 	"authors"    : [
 		{
 			"name"    : "Automattic",
-			"homepage": "http://automattic.com/"
+			"homepage": "https://automattic.com/"
 		},
 		{
 			"name"    : "Code For The People",
-			"homepage": "http://codeforthepeople.com/"
+			"homepage": "https://codeforthepeople.com/"
 		}
 	],
 	"support"    : {

--- a/mexp-creds.php
+++ b/mexp-creds.php
@@ -4,7 +4,7 @@ Plugin Name: MEXP oAuth Credentials
 Description: MEXP oAuth Credentials
 Version:     1.0
 Author:      John Blackbourn
-Author URI:  http://johnblackbourn.com/
+Author URI:  https://johnblackbourn.com/
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/mexp-keyring-user-creds.php
+++ b/mexp-keyring-user-creds.php
@@ -4,7 +4,7 @@ Plugin Name: MEXP Keyring Credentials
 Description: MEXP Keyring Credentials
 Version:     1.0
 Author:      Michael Blouin, Automattic
-Author URI:  http://automattic.com
+Author URI:  https://automattic.com
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/services/twitter/service.php
+++ b/services/twitter/service.php
@@ -135,7 +135,7 @@ class MEXP_Twitter_Service extends MEXP_Service {
 
 	public function get_coords( $location ) {
 
-		$url = sprintf( 'http://maps.googleapis.com/maps/api/geocode/json?address=%s&sensor=false',
+		$url = sprintf( 'https://maps.googleapis.com/maps/api/geocode/json?address=%s&sensor=false',
 			urlencode( trim( $location ) )
 		);
 		$result = wp_remote_get( $url );
@@ -274,7 +274,7 @@ class MEXP_Twitter_Service extends MEXP_Service {
 			# @TODO the 'insert' button text gets reset when selecting items. find out why.
 			'insert'    => __( 'Insert Tweet', 'mexp' ),
 			'noresults' => __( 'No tweets matched your search query', 'mexp' ),
-			'gmaps_url' => set_url_scheme( 'http://maps.google.com/maps/api/js' ),
+			'gmaps_url' => set_url_scheme( 'https://maps.google.com/maps/api/js', 'https' ),
 			'loadmore'  => __( 'Load more tweets', 'mexp' ),
 		);
 

--- a/services/youtube/service.php
+++ b/services/youtube/service.php
@@ -84,11 +84,11 @@ class MEXP_YouTube_Service extends MEXP_Service {
 		foreach ( $search_response['items'] as $index => $search_item ) {
 			$item = new MEXP_Response_Item();
 			if ( $request['type'] == 'video' && isset( $request['q'] ) ) { // For videos searched by query
-				$item->set_url( esc_url( sprintf( "http://www.youtube.com/watch?v=%s", $search_item['id']['videoId'] ) ) );
+				$item->set_url( esc_url( sprintf( "https://www.youtube.com/watch?v=%s", $search_item['id']['videoId'] ) ) );
 			} elseif( $request['type'] == 'playlist' && isset( $request['q'] ) ) { // For playlists searched by query
-				$item->set_url( esc_url( sprintf( "http://www.youtube.com/playlist?list=%s", $search_item['id']['playlistId'] ) ) );
+				$item->set_url( esc_url( sprintf( "https://www.youtube.com/playlist?list=%s", $search_item['id']['playlistId'] ) ) );
 			} else { // For videos searched by channel name
-				$item->set_url( esc_url( sprintf( "http://www.youtube.com/watch?v=%s", $search_item['snippet']['resourceId']['videoId'] ) ) );
+				$item->set_url( esc_url( sprintf( "https://www.youtube.com/watch?v=%s", $search_item['snippet']['resourceId']['videoId'] ) ) );
 			}
 			$item->add_meta( 'user', $search_item['snippet']['channelTitle'] );
 			$item->set_id( (int) $params['startIndex'] + (int) $index );


### PR DESCRIPTION
Old `http:` URLs (for services and Google) changed to current `https:` in strings (and comments). The Google maps `http:` URLs were 404s. The rest were redirects. 

In `/services/twitter/service.php` line 277, set the 2nd param of:
`'gmaps_url' => set_url_scheme( 'https://maps.google.com/maps/api/js', 'https' ),`

There may be more legacy non-https URLs being generated inside code, but I got the easy ones in strings.
