### PR TITLE
Allow 3rd-party plugins to use custom views and controllers

### DIFF
--- a/class.mexp.php
+++ b/class.mexp.php
@@ -210,11 +210,18 @@ class Media_Explorer extends MEXP_Plugin {
 
 			$tabs = apply_filters( 'mexp_tabs', array() );
 			$labels = apply_filters( 'mexp_labels', array() );
+			$js = apply_filters( "mexp_js_{$service_id}", array(
+				'item'       => 'media.view.MEXPItem',
+				'toolbar'    => 'media.view.Toolbar.MEXP',
+				'view'       => 'media.view.MEXP',
+				'controller' => 'media.controller.MEXP'
+			) );
 
 			$mexp['services'][$service_id] = array(
 				'id'     => $service_id,
 				'labels' => $labels[$service_id],
 				'tabs'   => $tabs[$service_id],
+				'js'     => $js
 			);
 		}
 

--- a/js/mexp.js
+++ b/js/mexp.js
@@ -170,7 +170,9 @@ media.view.MEXP = media.View.extend({
 
 	renderItem : function( model ) {
 
-		var view = new media.view.MEXPItem({
+		var item = stringToFunction( this.service.js.item );
+
+		var view = new item({
 			model   : model,
 			service : this.service,
 			tab     : this.tab
@@ -458,8 +460,10 @@ media.view.MediaFrame.Post = post_frame.extend({
 
 			}
 
+			var mexpController = stringToFunction( service.js.controller );
+
 			this.states.add([
-				new media.controller.MEXP( controller )
+				new mexpController( controller )
 			]);
 
 			// Tabs
@@ -504,8 +508,9 @@ media.view.MediaFrame.Post = post_frame.extend({
 	mexpContentRender : function( service, tab ) {
 
 		/* called when a tab becomes active */
+		var view = stringToFunction( service.js.view );
 
-		this.content.set( new media.view.MEXP( {
+		this.content.set( new view( {
 			service    : service,
 			controller : this,
 			model      : this.state().props.get( tab ),
@@ -516,8 +521,11 @@ media.view.MediaFrame.Post = post_frame.extend({
 	},
 
 	mexpToolbarCreate : function( toolbar ) {
+		var serviceId = this.state().id.replace( 'mexp-service-', '' ),
+			viewId = mexp['services'][serviceId]['js']['toolbar'],
+			view = stringToFunction( viewId );
 
-		toolbar.view = new media.view.Toolbar.MEXP( {
+		toolbar.view = new view( {
 			controller : this
 		} );
 
@@ -580,3 +588,20 @@ media.controller.MEXP = media.controller.State.extend({
 	}
 
 });
+
+// Instantiate a javascript object using a string.
+// @link http://stackoverflow.com/a/2441972
+var stringToFunction = function( str ) {
+	var arr = str.split( "." );
+
+	var fn = ( window || this );
+	for ( var i = 0, len = arr.length; i < len; i++ ) {
+		fn = fn[arr[i]];
+	}
+
+	if ( typeof fn !== "function" ) {
+		throw new Error( "function not found" );
+	}
+
+	return fn;
+};


### PR DESCRIPTION
MEXP's JS has hardcoded references to its own views and controllers.  This makes things impossible for more than one plugin to override these internals.

For example, MEXP's built-in YouTube service manually overrides MEXP's own `media.view.MEXP` and `media.view.Toolbar.MEXP`, so no other plugin can touch these without conflicts occurring:
https://github.com/Automattic/media-explorer/blob/master/js/mexp.js#L85
https://github.com/Automattic/media-explorer/blob/master/services/youtube/js.js#L11

https://github.com/Automattic/media-explorer/blob/master/js/mexp.js#L36
https://github.com/Automattic/media-explorer/blob/master/services/youtube/js.js#L219

This commit allows each service to set their own views and controllers and refactors MEXP to allow these views and controllers to be initialized.

Specifically, adds a JS utility function - `stringToFunction()` - so we can instantiate custom views (could do better here).

Plugins can override the default views and controllers by registering them on the `"mexp_js_{$service_id}"` hook.  See how we're using this hook with our [Google Drive MEXP plugin](https://github.com/hwdsbcommons/gdrive/commit/d405ac6ab390e32db29f1d9feb733b3756c4aed8).

I didn't change MEXP's YouTube JS to do this yet.  If this commit looks good in your eyes, then I'll add a commit for YouTube.
