### PR TITLE
handle IE11 bug with phantom image href attrs

### DIFF
--- a/js/mexp.js
+++ b/js/mexp.js
@@ -213,8 +213,8 @@ media.view.MEXP = media.View.extend({
 	},
 
 	toggleSelectionHandler: function( event ) {
-
-		if ( event.target.href )
+		// IE<=11 can add href property to HTMLImageElement
+		if ( event.target.href && 'IMG' !== event.target.nodeName )
 			return;
 
 		var target = jQuery( '#' + event.currentTarget.id );


### PR DESCRIPTION
HTMLImageElement sometimes has a mysterious `href` property in IE<=11, so checking `event.target.href` was returning false positives.